### PR TITLE
Dealing with zombie processes in the queue

### DIFF
--- a/inc/shell/ExternalProcess.php
+++ b/inc/shell/ExternalProcess.php
@@ -439,6 +439,10 @@ class ExternalProcess
 
         if ($noParent == False) {
             Log::error('Failed killing parent process.');
+            
+            //Good to report, but does that mean the parent cannot be killed or is already dead?
+            //TODO make a better test
+            $noParent = True;
         }
 
         return ($noParent && $noChild);


### PR DESCRIPTION
Hi Aaron, Daniel :)

So, here is my bodge!

I had a look at the logs when restarting hrmd and noticed that for each "zombie" job in the queue, an error (Failed killing parent process) was logged. This log is generated in [inc/shell/ExternalProcess.php](https://github.com/aarpon/hrm/blob/master/inc/shell/ExternalProcess.php#L437-L444)

So there is a question regarding what this actually means: 'is the parent process already dead or can it not be killed?' Being able to differentiate between these two conditions may be important, I don't know.

However, by setting `$noParent = True` (after we log the failure condition for future inspection), we have in [inc/job/JobQueue.php line 208](https://github.com/aarpon/hrm/blob/master/inc/job/JobQueue.php#L208):

`$killed = $proc->killHucoreProcess($pid);` resulting in `$killed = True`: We have just successfully _pretended_ that we did indeed kill the process, and thus is removed from the queue.

I accept I do not understand the details of how this (should) work(s)!

Kind regards,
Egor